### PR TITLE
Switch to PyPDF2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='stapler',
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'pypdf == 1.12',
+        'PyPDF2',
     ],
     entry_points="""
     [console_scripts]

--- a/staplelib/commands.py
+++ b/staplelib/commands.py
@@ -132,7 +132,7 @@ def info(args):
         info = pdf.documentInfo
         if info:
             for name, value in info.items():
-                print "    {}:  {}".format(name, value)
+                print u"    {}:  {}".format(name, value)
         else:
             print "    (No metadata found.)"
         print

--- a/staplelib/commands.py
+++ b/staplelib/commands.py
@@ -4,7 +4,7 @@ import math
 import os.path
 import os
 
-from pyPdf import PdfFileWriter, PdfFileReader
+from PyPDF2 import PdfFileWriter, PdfFileReader
 
 from . import CommandError, iohelper
 import staplelib

--- a/staplelib/iohelper.py
+++ b/staplelib/iohelper.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import sys
 
-from pyPdf import PdfFileWriter, PdfFileReader
+from PyPDF2 import PdfFileWriter, PdfFileReader
 
 from . import CommandError
 import staplelib
@@ -22,7 +22,7 @@ ROTATIONS = {'u': ROTATION_NONE,
 
 
 def read_pdf(filename):
-    """Open a PDF file with pyPdf."""
+    """Open a PDF file with PyPDF2."""
     if not os.path.exists(filename):
         raise CommandError("{} does not exist".format(filename))
     pdf = PdfFileReader(file(filename, "rb"))

--- a/staplelib/tests.py
+++ b/staplelib/tests.py
@@ -6,7 +6,7 @@ from subprocess import check_call
 import tempfile
 import unittest
 
-from pyPdf import PdfFileReader
+from PyPDF2 import PdfFileReader
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
PyPDF2 is an approved fork of pyPdf, since it's still developed stapler can use it instead of pyPdf
(it's fully compatible so no need to change a line of code apart from the imports).

I also added a commit to print pdfs' info using unicode, since I was getting a UnicodeEncodeError
from a pdf that has a ® in the Producer tag.