### PR TITLE
Add 'zip' command to stapler

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,3 +2,4 @@ Philip Stark <heller.barde at gmail dot com>
 Fred Wenzel <fwenzel at mozilla dot coms>
 Emanuele Santoro <manu at santoro dot tk>
 David Gay <oddshocks at gmail dot com>
+Carlchristian Eckert <Carli-Eckert at gmx dot de>

--- a/README.md
+++ b/README.md
@@ -80,6 +80,26 @@ Example for a file foobar.pdf with 20 pages:
 Multiple files can be specified, they will be processed as if you called
 single instances of stapler.
 
+### zip:
+With zip, you can cherry-pick pages from pdfs (like select). The pages from
+each pdf are merged together in an interleaving manner. This can be used to
+collate a pdf with odd pages and a pdf with even pages into a single file.
+
+Syntax:
+    stapler zip input1 [range[rotation]] [range ...] [input2 [range...] ...] out
+
+Examples:
+
+    # combine a pdf with odd pages and a pdf with even pages into output.pdf
+    stapler zip odd.pdf even.pdf output.pdf
+
+    # combine a.pdf b.pdf and c.pdf, but use only some pages of c.pdf
+    stapler zip a.pdf b.pdf c.pdf 1-3 output.pdf
+
+If one of the ranges is shorter than the others, stapler will continue to merge
+the remaining pages.
+
+
 ### info:
 Shows information on the metadata stored inside a PDF file.
 

--- a/staplelib/stapler.py
+++ b/staplelib/stapler.py
@@ -21,6 +21,8 @@ del: <inputfile> [<pagerange>[<rotation>]] ... (output needed)
     Select all but the given pages/ranges from input files.
 burst/split: <inputfile> ... (no output needed)
     Create one file per page in input pdf files (no output needed)
+zip: <inputfile> [<pagerange>[<rotation>]] ... (output needed)
+    Merge/Collate the given input files interleaved.
 info: <inputfile> ... (no output needed)
     Display PDF metadata
 
@@ -70,6 +72,7 @@ def main():
         "burst": commands.split,
         "del": commands.delete,
         "info": commands.info,
+        "zip": commands.zip,
     }
 
     mode = args[0]


### PR DESCRIPTION
 - syntax is equal to sel/cat:
   from each pdf, the selected pages are merged in an interleaving manner
 - can be used to combine even and odd pages (close #3)
 - updated README.md and CONTRIBUTORS

The merge operation does NOT stop once one of the inputs is exhausted, but continues with the remaining input ([done in roundrobinLIST](https://github.com/slizzered/stapler/compare/hellerbarde:master...slizzered:feature-zip?expand=1#diff-1d3c64e3c3d420175ec4da112e680e5dR14)). If the user does not want the whole file, there is the possibility to use ranges.

More than 2 input files are supported, the algorithm will then interleave all these inputs.