### PR TITLE
Add background command to overlay pages.

### DIFF
--- a/staplelib/commands.py
+++ b/staplelib/commands.py
@@ -177,7 +177,10 @@ def background(args):
         for pagelist in list(itertools.izip_longest(*filestozip)):
             page = pagelist[0]
             for p in pagelist[1:]:
-              if p: page.mergePage(p)
+              if not page:
+                page = p
+              elif p:
+                page.mergePage(p)
             output.addPage(page)
 
     except Exception, e:

--- a/staplelib/stapler.py
+++ b/staplelib/stapler.py
@@ -23,6 +23,8 @@ burst/split: <inputfile> ... (no output needed)
     Create one file per page in input pdf files (no output needed)
 zip: <inputfile> [<pagerange>[<rotation>]] ... (output needed)
     Merge/Collate the given input files interleaved.
+background: <inputfile> [<pagerange>[<rotation>]] ... (output needed)
+    Merge/Overlay the given input files interleaved.
 info: <inputfile> ... (no output needed)
     Display PDF metadata
 
@@ -73,6 +75,7 @@ def main():
         "del": commands.delete,
         "info": commands.info,
         "zip": commands.zip,
+        "background": commands.background,
     }
 
     mode = args[0]


### PR DESCRIPTION
With merge/overlay, you have a PDF of the form, and your app prints the data to another PDF, then you overlay them to see that the data aligns with the form fields, or the addresses align with the label outlines.

An example pdftk command was:
$ pdftk file1.pdf background file2.pdf output combinedfile.pdf

Could also do multibackground - which repeats the overlay (short pagelist) over all pages of the long pagelist.  Most commonly, this would be the same form repeated for all pages.