### PR TITLE
Select only even/odd pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,10 @@ Examples:
     # reverse some of the pages in a.pdf by specifying a negative range
     stapler sel a.pdf 1-3 9-6 10 output.pdf
 
+    # generate a pdf file called output.pdf with the following pages:
+    # 1,3,5,7,9 in 180° (D for down), 2,4,6,8,10 from a.pdf in this order
+    stapler sel a.pdf 1-10oddD 1-10even output.pdf
+
 The delete command works almost exactly the same as select, but inverse.
 It uses the pages and ranges which you *didn't* specify.
 

--- a/staplelib/iohelper.py
+++ b/staplelib/iohelper.py
@@ -43,8 +43,10 @@ def read_pdf(filename):
 
 
 def write_pdf(pdf, filename):
+    force = staplelib.OPTIONS.force
+
     """Write the content of a PdfFileWriter object to a file."""
-    if os.path.exists(filename):
+    if os.path.exists(filename) and not force:
         raise CommandError("File already exists: {}".format(filename))
 
     opt = staplelib.OPTIONS

--- a/staplelib/iohelper.py
+++ b/staplelib/iohelper.py
@@ -100,6 +100,7 @@ def parse_ranges(files_and_ranges):
 
             current = operations[-1]
             max_page = current['pdf'].getNumPages()
+            step_size = 1
             # allow "end" as alias for the last page
             replace_end = lambda page: (
                 max_page if page.lower() == 'end' else int(page))
@@ -116,9 +117,9 @@ def parse_ranges(files_and_ranges):
 
             # negative ranges sort pages backwards
             if begin < end:
-                pagerange = range(begin, end + 1)
+                pagerange = range(begin, end + 1, step_size)
             else:
-                pagerange = range(end, begin + 1)[::-1]
+                pagerange = range(end, begin - 1, step_size * -1 )
 
             for p in pagerange:
                 current['pages'].append((p, rotate))

--- a/staplelib/iohelper.py
+++ b/staplelib/iohelper.py
@@ -22,11 +22,7 @@ ROTATION_LEFT = 270
 ROTATIONS = {'u': ROTATION_NONE,
              'r': ROTATION_RIGHT,
              'd': ROTATION_TURN,
-             'l': ROTATION_LEFT,
-             'n': ROTATION_NONE,
-             'e': ROTATION_RIGHT,
-             's': ROTATION_TURN,
-             'w': ROTATION_LEFT}
+             'l': ROTATION_LEFT}
 
 HANDLES = {}
 
@@ -106,7 +102,7 @@ def parse_ranges(handles_files_and_ranges):
         else:
             handle_key = None
             handle_value = None
-            match = re.match('([A-Z])?([0-9]+|end)(?:-([0-9]+|end))?(even|odd)?([LRDWES]?)',
+            match = re.match('([A-Z])?([0-9]+|end)(?:-([0-9]+|end))?(even|odd)?([LRD]?)',
                                 inputname)
             if not match:
                 raise CommandError('Invalid range: {}'.format(inputname))

--- a/staplelib/iohelper.py
+++ b/staplelib/iohelper.py
@@ -22,7 +22,11 @@ ROTATION_LEFT = 270
 ROTATIONS = {'u': ROTATION_NONE,
              'r': ROTATION_RIGHT,
              'd': ROTATION_TURN,
-             'l': ROTATION_LEFT}
+             'l': ROTATION_LEFT,
+             'n': ROTATION_NONE,
+             'e': ROTATION_RIGHT,
+             's': ROTATION_TURN,
+             'w': ROTATION_LEFT}
 
 
 def read_pdf(filename):
@@ -93,7 +97,7 @@ def parse_ranges(files_and_ranges):
                                "pdf": read_pdf(inputname),
                                "pages": []})
         else:
-            match = re.match('([0-9]+|end)(?:-([0-9]+|end))?(even|odd)?([LRD]?)',
+            match = re.match('([0-9]+|end)(?:-([0-9]+|end))?(even|odd)?([LRDWES]?)',
                                 inputname)
             if not match:
                 raise CommandError('Invalid range: {}'.format(inputname))

--- a/staplelib/stapler.py
+++ b/staplelib/stapler.py
@@ -58,6 +58,9 @@ parser.add_option('-u', '--userpw', action='store', dest='userpw',
                   default=None)
 parser.add_option('-v', '--verbose', action='store_true', dest='verbose',
                   default=False)
+parser.add_option('-f', '--force', action='store_true', dest='force',
+                  help='Overwrite output file if it exists',
+                  default=False)
 parser.add_option('-d', '--destdir', dest="destdir", default="." + os.sep,
                   help="directory where to store output file",)
 

--- a/staplelib/stapler.py
+++ b/staplelib/stapler.py
@@ -46,7 +46,6 @@ Extended page range options:
     end-... will be replaced with the last page in the file
     L, R, or D will rotate the respective range -90, +90, or 180 degrees,
         respectively. (e.g., 1-15R)
-    W, E, and S are aliases for L, R and D, respectively
 """.strip()
 
 # command line option parser

--- a/staplelib/stapler.py
+++ b/staplelib/stapler.py
@@ -14,16 +14,16 @@ USAGE = """
 usage: %prog [options] mode input.pdf ... [output.pdf]
 
 Modes:
-cat/sel: <inputfile> [<pagerange>[<rotation>]] ... (output needed)
+cat/sel: <inputfile> [<pagerange>[<pagesubset>][<rotation>]] ... (output needed)
     Select the given pages/ranges from input files.
     No range means all pages.
-del: <inputfile> [<pagerange>[<rotation>]] ... (output needed)
+del: <inputfile> [<pagerange>[<pagesubset>][<rotation>]] ... (output needed)
     Select all but the given pages/ranges from input files.
 burst/split: <inputfile> ... (no output needed)
     Create one file per page in input pdf files (no output needed)
 zip: <inputfile> [<pagerange>[<rotation>]] ... (output needed)
     Merge/Collate the given input files interleaved.
-background: <inputfile> [<pagerange>[<rotation>]] ... (output needed)
+background: <inputfile> [<pagerange>[<pagesubset>][<rotation>]] ... (output needed)
     Merge/Overlay the given input files interleaved.
 info: <inputfile> ... (no output needed)
     Display PDF metadata
@@ -33,9 +33,14 @@ Page ranges:
     n-m - page ranges include the entire specified range (e.g. 1-6)
     m-n - negative ranges sort pages backwards (e.g., 6-3)
 
+Page subsets:
+    even - only even numbered pages in the specified pagerange will be included
+    odd - only odd numbered pages in the specified pagerange will be included
+
 Extended page range options:
     ...-end will be replaced with the last page in the file
-    R, L, or D will rotate the respective range +90, -90, or 180 degrees,
+    end-... will be replaced with the last page in the file
+    L, R, or D will rotate the respective range -90, +90, or 180 degrees,
         respectively. (e.g., 1-15R)
 """.strip()
 

--- a/staplelib/stapler.py
+++ b/staplelib/stapler.py
@@ -42,6 +42,7 @@ Extended page range options:
     end-... will be replaced with the last page in the file
     L, R, or D will rotate the respective range -90, +90, or 180 degrees,
         respectively. (e.g., 1-15R)
+    W, E, and S are aliases for L, R and D, respectively
 """.strip()
 
 # command line option parser


### PR DESCRIPTION
This adds the ability to select even/odd pages with the same syntax as pdftk. Examples were added to the documentation and the usage statement.