### PR TITLE
Ensure more-itertools dependency works on Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,14 @@ setup(name="stapler",
     version=version,
     description="Manipulate PDF documents from the command line",
     keywords="pdf utility cli concatenate tool",
-    
+
     author="Philip Stark, Fred Wenzel",
     author_email="git@codechaos.ch",
     url="https://github.com/hellerbarde/stapler",
 
     install_requires = [
         "PyPDF2>=1.24",
-        "more-itertools>=2.2"
+        "more-itertools>=2.2,<6.0.0"
     ],
 
     include_package_data=True,


### PR DESCRIPTION
`more-itertools` stopped supporting Python 2 in version 6.0.0.

Currently this project's `setup.py` file specifies versions `>=2.2`. This will attempt to get an incompatible version as is.

This PR sets the `more-itertools` version such that it will still work on Python 2.7.