### PR TITLE
Python 3 compatibility, new tests and tox configuration for stapler

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@ Emanuele Santoro <manu at santoro dot tk>
 David Gay <oddshocks at gmail dot com>
 Carlchristian Eckert <Carli-Eckert at gmx dot de>
 John Heidemann <johnh at isi dot edu>
+Lumír Balhar <lbalhar at redhat dot com>

--- a/staplelib/commands.py
+++ b/staplelib/commands.py
@@ -1,4 +1,5 @@
 """Module containing the actual commands stapler understands."""
+from __future__ import print_function
 import math
 import os
 
@@ -33,7 +34,7 @@ def select(args, inverse=False):
         for input in filesandranges:
             pdf = input['pdf']
             if verbose:
-                print input['name']
+                print(input['name'])
 
             # empty range means "include all pages"
             if not inverse:
@@ -49,8 +50,8 @@ def select(args, inverse=False):
             for pageno, rotate in pagerange:
                 if 1 <= pageno <= pdf.getNumPages():
                     if verbose:
-                        print "Using page: {} (rotation: {} deg.)".format(
-                            pageno, rotate)
+                        print("Using page: {} (rotation: {} deg.)".format(
+                            pageno, rotate))
 
                     output.addPage(pdf.getPage(pageno-1)
                                    .rotateClockwise(rotate))
@@ -108,15 +109,15 @@ def split(args):
 
             outputname = output_template % (pageno + 1)
             if verbose:
-                print outputname
+                print(outputname)
             iohelper.write_pdf(output, staplelib.OPTIONS.destdir +
                                os.sep + outputname)
             pagecount += 1
         filecount += 1
 
     if verbose:
-        print "\n{} page(s) in {} file(s) processed.".format(
-            pagecount, filecount)
+        print("\n{} page(s) in {} file(s) processed.".format(
+            pagecount, filecount))
 
 
 def info(args):
@@ -128,15 +129,15 @@ def info(args):
 
     for f in files:
         pdf = iohelper.read_pdf(f)
-        print "*** Metadata for {}".format(f)
-        print
+        print("*** Metadata for {}".format(f))
+        print()
         info = pdf.documentInfo
         if info:
             for name, value in info.items():
-                print u"    {}:  {}".format(name, value)
+                print(u"    {}:  {}".format(name, value))
         else:
-            print "    (No metadata found.)"
-        print
+            print("    (No metadata found.)")
+        print()
 
 def background(args):
     """Combine 2 files with corresponding pages merged."""
@@ -153,7 +154,7 @@ def background(args):
         for input in filesandranges:
             pdf = input['pdf']
             if verbose:
-                print input['name']
+                print(input['name'])
 
             # empty range means "include all pages"
             pagerange = input['pages'] or [
@@ -164,8 +165,8 @@ def background(args):
             for pageno, rotate in pagerange:
                 if 1 <= pageno <= pdf.getNumPages():
                     if verbose:
-                        print "Using page: {} (rotation: {} deg.)".format(
-                            pageno, rotate)
+                        print("Using page: {} (rotation: {} deg.)".format(
+                            pageno, rotate))
 
                     pagestozip.append(pdf.getPage(pageno-1)
                                    .rotateClockwise(rotate))
@@ -210,7 +211,7 @@ def zip(args):
     for input in filesandranges:
         pdf = input['pdf']
         if verbose:
-            print input['name']
+            print(input['name'])
 
         # Empty range means "include all pages".
         pagerange = input['pages'] or [
@@ -221,8 +222,8 @@ def zip(args):
         for pageno, rotate in pagerange:
             if 1 <= pageno <= pdf.getNumPages():
                 if verbose:
-                    print "Using page: {} (rotation: {} deg.)".format(
-                        pageno, rotate)
+                    print("Using page: {} (rotation: {} deg.)".format(
+                        pageno, rotate))
 
                 pagestozip.append(
                     pdf.getPage(pageno - 1).rotateClockwise(rotate))
@@ -351,11 +352,11 @@ def list_logical_pages(args):
         for input in files:
             pdf = iohelper.read_pdf(input)
             if verbose:
-                print input
+                print(input)
             i = 0
             for label in pdf_page_enumeration(pdf):
                 i += 1
-                print "{}\t{}".format(label, str(i))
+                print("{}\t{}".format(label, str(i)))
 
     except Exception, e:
         raise CommandError(e)

--- a/staplelib/commands.py
+++ b/staplelib/commands.py
@@ -59,7 +59,7 @@ def select(args, inverse=False):
                     raise CommandError("Page {} not found in {}.".format(
                         pageno, input['name']))
 
-    except Exception, e:
+    except Exception as e:
         raise CommandError(e)
 
     if os.path.isabs(outputfilename):
@@ -86,7 +86,7 @@ def split(args):
     try:
         for f in files:
             inputs.append(iohelper.read_pdf(f))
-    except Exception, e:
+    except Exception as e:
         raise CommandError(e)
 
     filecount = 0
@@ -185,7 +185,7 @@ def background(args):
                 page.mergePage(p)
             output.addPage(page)
 
-    except Exception, e:
+    except Exception as e:
         import sys
         import traceback
         traceback.print_tb(sys.exc_info()[2])
@@ -258,9 +258,9 @@ def int_to_roman(input):
     """ Convert an integer to a Roman numeral. """
 
     if not isinstance(input, type(1)):
-        raise TypeError, "expected integer, got %s" % type(input)
+        raise TypeError("expected integer, got %s" % type(input))
     if not 0 < input < 4000:
-        raise ValueError, "Argument must be between 1 and 3999"
+        raise ValueError("Argument must be between 1 and 3999")
     ints = (1000, 900,  500, 400, 100,  90, 50,  40, 10,  9,   5,  4,   1)
     nums = ('M',  'CM', 'D', 'CD','C', 'XC','L','XL','X','IX','V','IV','I')
     result = []
@@ -358,5 +358,5 @@ def list_logical_pages(args):
                 i += 1
                 print("{}\t{}".format(label, str(i)))
 
-    except Exception, e:
+    except Exception as e:
         raise CommandError(e)

--- a/staplelib/iohelper.py
+++ b/staplelib/iohelper.py
@@ -1,5 +1,6 @@
 """Helper functions for user-supplied arguments and file I/O."""
 
+from __future__ import print_function
 import getpass
 import os.path
 import re
@@ -38,7 +39,7 @@ def read_pdf(filename):
             if matched:
                 break
             else:
-                print "The password did not match."
+                print("The password did not match.")
     return pdf
 
 
@@ -61,8 +62,8 @@ def write_pdf(pdf, filename):
 
 def prompt_for_pw(filename):
     """Prompt the user for the password to access an input file."""
-    print 'Please enter a password to decrypt {}.'.format(filename)
-    print '(The password will not be shown. Press ^C to cancel).'
+    print('Please enter a password to decrypt {}.'.format(filename))
+    print('(The password will not be shown. Press ^C to cancel).')
 
     try:
         return getpass.getpass('--> ')

--- a/staplelib/iohelper.py
+++ b/staplelib/iohelper.py
@@ -31,7 +31,7 @@ def read_pdf(filename):
     """Open a PDF file with PyPDF2."""
     if not os.path.exists(filename):
         raise CommandError("{} does not exist".format(filename))
-    pdf = PdfFileReader(file(filename, "rb"))
+    pdf = PdfFileReader(open(filename, "rb"))
     if pdf.isEncrypted:
         while True:
             pw = prompt_for_pw(filename)
@@ -55,7 +55,7 @@ def write_pdf(pdf, filename):
         if opt.ownerpw or opt.userpw:
             pdf.encrypt(opt.userpw or '', opt.ownerpw)
 
-    outputStream = file(filename, "wb")
+    outputStream = open(filename, "wb")
     pdf.write(outputStream)
     outputStream.close()
 

--- a/staplelib/stapler.py
+++ b/staplelib/stapler.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Main stapler dispatcher."""
 
+from __future__ import print_function
 from optparse import OptionParser
 import os
 import sys
@@ -95,7 +96,7 @@ def main():
         print_error('Please enter a valid mode', show_usage=True)
 
     if staplelib.OPTIONS.verbose:
-        print "Mode: %s" % mode
+        print("Mode: %s" % mode)
 
     # dispatch call to known subcommand
     try:

--- a/staplelib/stapler.py
+++ b/staplelib/stapler.py
@@ -101,7 +101,7 @@ def main():
     # dispatch call to known subcommand
     try:
         modes[mode](args)
-    except CommandError, e:
+    except CommandError as e:
         print_error(e)
 
 

--- a/staplelib/tests.py
+++ b/staplelib/tests.py
@@ -36,7 +36,7 @@ class TestStapler(unittest.TestCase):
         check_call([STAPLER, 'cat', ONEPAGE_PDF, FIVEPAGE_PDF,
                     self.outputfile])
         self.assert_(os.path.isfile(self.outputfile))
-        pdf = PdfFileReader(file(self.outputfile, 'rb'))
+        pdf = PdfFileReader(open(self.outputfile, 'rb'))
         self.assertEqual(pdf.getNumPages(), 6)
 
     def test_split(self):
@@ -46,7 +46,7 @@ class TestStapler(unittest.TestCase):
         filelist = os.listdir(self.tmpdir)
         self.assertEqual(len(filelist), 5)
         for f in os.listdir(self.tmpdir):
-            pdf = PdfFileReader(file(os.path.join(self.tmpdir, f), 'rb'))
+            pdf = PdfFileReader(open(os.path.join(self.tmpdir, f), 'rb'))
             self.assertEqual(pdf.getNumPages(), 1)
 
 

--- a/staplelib/tests.py
+++ b/staplelib/tests.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-import os.path
+import os
 import shutil
-from subprocess import check_call
+from subprocess import check_call, CalledProcessError
 import tempfile
 import unittest
 
@@ -11,6 +11,11 @@ try:
 except ImportError:
     from pyPdf import PdfFileReader
 
+try:
+    from subprocess import DEVNULL  # Python >= 3.3
+except ImportError:
+    import os
+    DEVNULL = open(os.devnull, 'wb')
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 TESTFILE_DIR = os.path.join(HERE, 'testfiles')
@@ -40,6 +45,42 @@ class TestStapler(unittest.TestCase):
             pdf = PdfFileReader(outputfile)
             self.assertEqual(pdf.getNumPages(), 6)
 
+    def test_sel_one_page(self):
+        """Test select of a one page from a PDF file."""
+        check_call([STAPLER, 'sel', 'A='+FIVEPAGE_PDF, 'A2',
+                    self.outputfile])
+        self.assertTrue(os.path.isfile(self.outputfile))
+        with open(self.outputfile, 'rb') as outputfile:
+            pdf = PdfFileReader(outputfile)
+            self.assertEqual(pdf.getNumPages(), 1)
+
+    def test_sel_range(self):
+        """Test select of more pages from a PDF file."""
+        check_call([STAPLER, 'cat', 'A='+FIVEPAGE_PDF, 'A2-4',
+                    self.outputfile])
+        self.assertTrue(os.path.isfile(self.outputfile))
+        with open(self.outputfile, 'rb') as outputfile:
+            pdf = PdfFileReader(outputfile)
+            self.assertEqual(pdf.getNumPages(), 3)
+
+    def test_del_one_page(self):
+        """Test del command for inverse select of one page."""
+        check_call([STAPLER, 'del', 'A='+FIVEPAGE_PDF, 'A1',
+                    self.outputfile])
+        self.assertTrue(os.path.isfile(self.outputfile))
+        with open(self.outputfile, 'rb') as outputfile:
+            pdf = PdfFileReader(outputfile)
+            self.assertEqual(pdf.getNumPages(), 4)
+
+    def test_del_range(self):
+        """Test del command for inverse select multiple pages."""
+        check_call([STAPLER, 'del', 'A='+FIVEPAGE_PDF, 'A2-4',
+                    self.outputfile])
+        self.assertTrue(os.path.isfile(self.outputfile))
+        with open(self.outputfile, 'rb') as outputfile:
+            pdf = PdfFileReader(outputfile)
+            self.assertEqual(pdf.getNumPages(), 2)
+
     def test_split(self):
         """Make sure a file is properly split into pages."""
         check_call([STAPLER, 'split', FIVEPAGE_PDF])
@@ -51,6 +92,22 @@ class TestStapler(unittest.TestCase):
                 pdf = PdfFileReader(pdf_file)
                 self.assertEqual(pdf.getNumPages(), 1)
 
+    def test_zip(self):
+        """Test zip."""
+        check_call([STAPLER, 'zip', ONEPAGE_PDF, FIVEPAGE_PDF,
+                    self.outputfile])
+        self.assertTrue(os.path.isfile(self.outputfile))
+        with open(self.outputfile, 'rb') as outputfile:
+            pdf = PdfFileReader(outputfile)
+            self.assertEqual(pdf.getNumPages(), 6)
+
+    def test_output_file_already_exists(self):
+        """Test zip."""
+        with self.assertRaises(CalledProcessError) as e:
+            check_call([STAPLER, 'zip', ONEPAGE_PDF, FIVEPAGE_PDF],
+                       stderr=DEVNULL)
+            self.assertEqual(e.returncode, 1)
+            self.assertIn('Error: File already exists:', e.output)
 
 if __name__ == '__main__':
     unittest.main()

--- a/staplelib/tests.py
+++ b/staplelib/tests.py
@@ -35,9 +35,10 @@ class TestStapler(unittest.TestCase):
         """Make sure files are properly concatenated."""
         check_call([STAPLER, 'cat', ONEPAGE_PDF, FIVEPAGE_PDF,
                     self.outputfile])
-        self.assert_(os.path.isfile(self.outputfile))
-        pdf = PdfFileReader(open(self.outputfile, 'rb'))
-        self.assertEqual(pdf.getNumPages(), 6)
+        self.assertTrue(os.path.isfile(self.outputfile))
+        with open(self.outputfile, 'rb') as outputfile:
+            pdf = PdfFileReader(outputfile)
+            self.assertEqual(pdf.getNumPages(), 6)
 
     def test_split(self):
         """Make sure a file is properly split into pages."""
@@ -46,8 +47,9 @@ class TestStapler(unittest.TestCase):
         filelist = os.listdir(self.tmpdir)
         self.assertEqual(len(filelist), 5)
         for f in os.listdir(self.tmpdir):
-            pdf = PdfFileReader(open(os.path.join(self.tmpdir, f), 'rb'))
-            self.assertEqual(pdf.getNumPages(), 1)
+            with open(os.path.join(self.tmpdir, f), 'rb') as pdf_file:
+                pdf = PdfFileReader(pdf_file)
+                self.assertEqual(pdf.getNumPages(), 1)
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27,py34,py35,py36,py37,py38,pypy,pypy3
+
+[testenv]
+commands = python -m unittest discover


### PR DESCRIPTION
Hello.

This makes stapler Python 3 compatible while keeping compatibility with Python 2.7, adds more tests and tox configuration.

Fixes: https://github.com/hellerbarde/stapler/issues/54
Replaces: https://github.com/hellerbarde/stapler/pull/20