### PR TITLE
Made to work on python3.7

### DIFF
--- a/staplelib/__init__.py
+++ b/staplelib/__init__.py
@@ -8,5 +8,5 @@ OPTIONS = None # optparse options
 
 
 def main():
-    import stapler
+    from . import stapler
     stapler.main()

--- a/stapler
+++ b/stapler
@@ -7,7 +7,7 @@ from staplelib import stapler
 
 __author__ = 'Philip Stark, Fred Wenzel'
 __license__ = 'BSD'
-VERSION = (0, 3, 3)
+VERSION = (0, 3, 4)
 __version__ = '.'.join(map(str, VERSION))
 
 


### PR DESCRIPTION
The `import stapler` in `__init__.py` failed with an import error. Changed to `from . import stapler`. I  tested on  python2.7 and that also works.

I've upgraded the version 0.3.4 but that's off course up to you.

Thanks for this tool anyway, I use it a lot!!!