### PR TITLE
Show repository and bug tracker urls on pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,13 @@ description = "Manipulate PDF documents from the command line"
 authors = ["Philip Stark", "Fred Wenzel"]
 license = "BSD-3-Clause"
 readme = 'README.rst'
+repository = "https://github.com/hellerbarde/stapler"
 packages = [
     { include = "staplelib" },
 ]
+
+[tool.poetry.urls]
+"Bug Tracker" = "https://github.com/hellerbarde/stapler/issues"
 
 [tool.poetry.dependencies]
 python = "^3.4"


### PR DESCRIPTION
I discovered this project in PyPI while looking for an updated fork of pypdf2. I noticed that in PyPI the project repository is not shown. This pull-request fix this.

https://python-poetry.org/docs/pyproject/#repository
https://python-poetry.org/docs/pyproject/#urls
