### PR TITLE
Update iohelper.py

### DIFF
--- a/staplelib/iohelper.py
+++ b/staplelib/iohelper.py
@@ -33,12 +33,11 @@ def read_pdf(filename):
         raise CommandError("{} does not exist".format(filename))
     pdf = PdfFileReader(open(filename, "rb"))
     if pdf.isEncrypted:
-        while True:
+        matched = pdf.decrypt('')
+        while not matched:
             pw = prompt_for_pw(filename)
             matched = pdf.decrypt(pw)
-            if matched:
-                break
-            else:
+            if not matched:
                 print("The password did not match.")
     return pdf
 


### PR DESCRIPTION
Some PDFs are tagged as encrypted, even though they aren't encrypted, and will open without a password prompt in a GUI PDF reader. This change attempts to "decrypt" with a blank password, before prompting for a password. This opens these troublesome files without a password prompt and allows stapler automation tasks to run.