### PR TITLE
pyproject.toml: use poetry-core backend for PEP517

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,5 @@ pdf-stapler = 'staplelib:main'
 
 # this section is for PEP517 compliance. It is technically unnecessary if using Poetry
 [build-system]
-requires = ["poetry>=1.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/staplelib/iohelper.py
+++ b/staplelib/iohelper.py
@@ -7,9 +7,9 @@ import re
 import sys
 
 try:
-    from PyPDF2 import PdfFileWriter, PdfFileReader
+    from PyPDF2 import PdfWriter, PdfReader
 except ImportError:
-    from pyPdf import PdfFileWriter, PdfFileReader
+    from pyPdf import PdfWriter, PdfReader
 
 
 from . import CommandError
@@ -31,8 +31,8 @@ def read_pdf(filename):
     """Open a PDF file with PyPDF2."""
     if not os.path.exists(filename):
         raise CommandError("{} does not exist".format(filename))
-    pdf = PdfFileReader(open(filename, "rb"))
-    if pdf.isEncrypted:
+    pdf = PdfReader(open(filename, "rb"))
+    if pdf.is_encrypted:
         while True:
             pw = prompt_for_pw(filename)
             matched = pdf.decrypt(pw)
@@ -46,7 +46,7 @@ def read_pdf(filename):
 def write_pdf(pdf, filename):
     force = staplelib.OPTIONS.force
 
-    """Write the content of a PdfFileWriter object to a file."""
+    """Write the content of a PdfWriter object to a file."""
     if os.path.exists(filename) and not force:
         raise CommandError("File already exists: {}".format(filename))
 
@@ -123,7 +123,7 @@ def parse_ranges(handles_files_and_ranges):
                         "page range '{}'".format(handle_key, inputname))
 
             current = operations[-1]
-            max_page = current['pdf'].getNumPages()
+            max_page = len(current['pdf'].pages)
             # allow "end" as alias for the last page
             replace_end = lambda page: (
                 max_page if page.lower() == 'end' else int(page))

--- a/staplelib/tests.py
+++ b/staplelib/tests.py
@@ -5,7 +5,7 @@ import shutil
 import tempfile
 import unittest
 
-from PyPDF2.pdf import PdfFileReader
+from PyPDF2.pdf import PdfReader
 
 from staplelib import main, CommandError
 
@@ -38,40 +38,40 @@ class TestStapler(unittest.TestCase):
                      self.outputfile])
         self.assertTrue(os.path.isfile(self.outputfile))
         with open(self.outputfile, 'rb') as outputfile:
-            pdf = PdfFileReader(outputfile)
-            self.assertEqual(pdf.getNumPages(), 6)
+            pdf = PdfReader(outputfile)
+            self.assertEqual(len(pdf.pages), 6)
 
     def test_sel_one_page(self):
         """Test select of a one page from a PDF file."""
         run_stapler(['sel', 'A=' + FIVEPAGE_PDF, 'A2', self.outputfile])
         self.assertTrue(os.path.isfile(self.outputfile))
         with open(self.outputfile, 'rb') as outputfile:
-            pdf = PdfFileReader(outputfile)
-            self.assertEqual(pdf.getNumPages(), 1)
+            pdf = PdfReader(outputfile)
+            self.assertEqual(len(pdf.pages), 1)
 
     def test_sel_range(self):
         """Test select of more pages from a PDF file."""
         run_stapler(['cat', 'A=' + FIVEPAGE_PDF, 'A2-4', self.outputfile])
         self.assertTrue(os.path.isfile(self.outputfile))
         with open(self.outputfile, 'rb') as outputfile:
-            pdf = PdfFileReader(outputfile)
-            self.assertEqual(pdf.getNumPages(), 3)
+            pdf = PdfReader(outputfile)
+            self.assertEqual(len(pdf.pages), 3)
 
     def test_del_one_page(self):
         """Test del command for inverse select of one page."""
         run_stapler(['del', 'A=' + FIVEPAGE_PDF, 'A1', self.outputfile])
         self.assertTrue(os.path.isfile(self.outputfile))
         with open(self.outputfile, 'rb') as outputfile:
-            pdf = PdfFileReader(outputfile)
-            self.assertEqual(pdf.getNumPages(), 4)
+            pdf = PdfReader(outputfile)
+            self.assertEqual(len(pdf.pages), 4)
 
     def test_del_range(self):
         """Test del command for inverse select multiple pages."""
         run_stapler(['del', 'A=' + FIVEPAGE_PDF, 'A2-4', self.outputfile])
         self.assertTrue(os.path.isfile(self.outputfile))
         with open(self.outputfile, 'rb') as outputfile:
-            pdf = PdfFileReader(outputfile)
-            self.assertEqual(pdf.getNumPages(), 2)
+            pdf = PdfReader(outputfile)
+            self.assertEqual(len(pdf.pages), 2)
 
     def test_split(self):
         """Make sure a file is properly split into pages."""
@@ -81,24 +81,24 @@ class TestStapler(unittest.TestCase):
         self.assertEqual(len(filelist), 5)
         for f in os.listdir(self.tmpdir):
             with open(os.path.join(self.tmpdir, f), 'rb') as pdf_file:
-                pdf = PdfFileReader(pdf_file)
-                self.assertEqual(pdf.getNumPages(), 1)
+                pdf = PdfReader(pdf_file)
+                self.assertEqual(len(pdf.pages), 1)
 
     def test_background(self):
         """Test background."""
         run_stapler(['background', ONEPAGE_PDF, FIVEPAGE_PDF, self.outputfile])
         self.assertTrue(os.path.isfile(self.outputfile))
         with open(self.outputfile, 'rb') as outputfile:
-            pdf = PdfFileReader(outputfile)
-            self.assertEqual(pdf.getNumPages(), 5)
+            pdf = PdfReader(outputfile)
+            self.assertEqual(len(pdf.pages), 5)
 
     def test_zip(self):
         """Test zip."""
         run_stapler(['zip', ONEPAGE_PDF, FIVEPAGE_PDF, self.outputfile])
         self.assertTrue(os.path.isfile(self.outputfile))
         with open(self.outputfile, 'rb') as outputfile:
-            pdf = PdfFileReader(outputfile)
-            self.assertEqual(pdf.getNumPages(), 6)
+            pdf = PdfReader(outputfile)
+            self.assertEqual(len(pdf.pages), 6)
 
     def test_output_file_already_exists(self):
         """Test zip."""


### PR DESCRIPTION
Per poetry upstream, "If your pyproject.toml file still references
poetry directly as a build backend, you should update it to reference
poetry-core instead."

https://python-poetry.org/docs/pyproject/#poetry-and-pep-517
https://projects.gentoo.org/python/guide/distutils.html#deprecated-pep-517-backends

Signed-off-by: Ben Kohler <bkohler@gentoo.org>