### PR TITLE
pyproject.toml: use poetry-core backend for PEP517

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,5 @@ pdf-stapler = 'staplelib:main'
 
 # this section is for PEP517 compliance. It is technically unnecessary if using Poetry
 [build-system]
-requires = ["poetry>=1.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Per poetry upstream, "If your pyproject.toml file still references poetry directly as a build backend, you should update it to reference poetry-core instead."

https://python-poetry.org/docs/pyproject/#poetry-and-pep-517 https://projects.gentoo.org/python/guide/distutils.html#deprecated-pep-517-backends

Signed-off-by: Ben Kohler <bkohler@gentoo.org>